### PR TITLE
Typo on blue powder

### DIFF
--- a/items/matrix_crystals.json
+++ b/items/matrix_crystals.json
@@ -160,7 +160,7 @@
   {
     "type": "GENERIC",
     "id": "matrix_crystal_teleport_dust_refined",
-    "name": { "str_sp": "refined matrix crystal, blue" },
+    "name": { "str_sp": "refined matrix crystal powder, blue" },
     "description": "Concentrated matrix crystal dust.  It glitters blue even in complete darkness.",
     "copy-from": "matrix_crystal_biokin_dust_refined",
     "color": "blue"


### PR DESCRIPTION
Missing 'powder' on refined blue crystal powder